### PR TITLE
Fix ai chat page sign in flow

### DIFF
--- a/src/components/onboarding/LoginScreen.tsx
+++ b/src/components/onboarding/LoginScreen.tsx
@@ -51,6 +51,7 @@ export default function LoginScreen({
       backgroundRepeat: 'no-repeat'
     }}>
         <div className="w-full max-w-sm p-8 flex flex-col items-center my-0 py-[32px]">
+          <h2 className="text-white text-2xl font-fustat font-medium mb-6 text-center">Bem-vindo! Faça login para continuar</h2>
           <form onSubmit={handleSubmit} className="space-y-6 my-0 py-[10px]">
             <div className="space-y-2">
               <Label htmlFor="email" className="text-white font-fustat font-medium" style={{

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -12,13 +12,12 @@ interface AuthContextValue {
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
+  // Always start with logged_out to ensure proper flow demonstration
   const [stage, setStage] = useState<AuthStage>("logged_out");
 
   useEffect(() => {
-    const saved = localStorage.getItem("auth_stage");
-    if (saved === "authenticated" || saved === "onboarding" || saved === "logged_out") {
-      setStage(saved);
-    }
+    // Clear any existing auth state to ensure fresh start
+    localStorage.removeItem("auth_stage");
   }, []);
 
   useEffect(() => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,11 +1,19 @@
 import React, { useState } from 'react';
-import { Columns2, Plus, MessageSquareText, FolderCheck, Settings, User, ChevronDown, Copy, ArrowUp, ArrowRight } from 'lucide-react';
+import { Columns2, Plus, MessageSquareText, FolderCheck, Settings, User, ChevronDown, Copy, ArrowUp, ArrowRight, LogOut } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { useAuth } from '@/lib/auth';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 const Index = () => {
   const [inputValue, setInputValue] = useState('');
+  const { logout } = useAuth();
   const sidebarIcons = [{
     icon: Columns2,
     label: 'Expandir menu'
@@ -44,9 +52,19 @@ const Index = () => {
         
         {/* Ícone User na parte inferior */}
         <div className="pb-8">
-          <button className="text-white hover:opacity-75 transition-opacity duration-200 group relative" title={sidebarIcons[sidebarIcons.length - 1].label}>
-            <User size={24} strokeWidth={1.5} />
-          </button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="text-white hover:opacity-75 transition-opacity duration-200 group relative" title={sidebarIcons[sidebarIcons.length - 1].label}>
+                <User size={24} strokeWidth={1.5} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuItem onClick={logout} className="cursor-pointer">
+                <LogOut className="mr-2 h-4 w-4" />
+                <span>Sair</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
 


### PR DESCRIPTION
Ensure the full sign-in and onboarding flow is shown by resetting the authentication state and adding a logout option.

The app was bypassing the sign-in page because the authentication state was persistently stored as "authenticated" in local storage. This PR modifies the authentication provider to always start in a logged-out state, forcing the user through the sign-in and onboarding process. A logout option was also added to the AI chat page for easier demonstration of the complete flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b903829-e421-4a05-9084-38b7a65d92d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b903829-e421-4a05-9084-38b7a65d92d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

