### PR TITLE
Fix ai chat page sign in flow

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,8 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { useAuth } from "@/lib/auth";
+
 const Index = () => {
   const [inputValue, setInputValue] = useState('');
   const sidebarIcons = [{
@@ -25,6 +27,8 @@ const Index = () => {
     icon: User,
     label: 'Perfil'
   }];
+  const { logout } = useAuth();
+
   const notesData = [{
     time: 'Há 5 min.',
     content: 'A análise do fluxo de Onboarding mostra abandono na etapa com a seleção das opções. Hipótese: talvez falte clareza para que o usuário siga as opções. Acho que se repensar a estratégia e reformular a usabilidade com tooltips e toast de apoio pode ajudar.'
@@ -44,7 +48,7 @@ const Index = () => {
         
         {/* Ícone User na parte inferior */}
         <div className="pb-8">
-          <button className="text-white hover:opacity-75 transition-opacity duration-200 group relative" title={sidebarIcons[sidebarIcons.length - 1].label}>
+          <button onClick={logout} className="text-white hover:opacity-75 transition-opacity duration-200 group relative" title="Sair">
             <User size={24} strokeWidth={1.5} />
           </button>
         </div>


### PR DESCRIPTION
Add a sign-out button to the AI chat page to enable viewing the full authentication flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bce2e0b-d78e-436a-ba41-aea8bdd3af24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3bce2e0b-d78e-436a-ba41-aea8bdd3af24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

