### PR TITLE
Fix ai chat page sign in flow

### DIFF
--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -7,6 +7,7 @@ interface AuthContextValue {
   login: () => void;
   completeOnboarding: () => void;
   logout: () => void;
+  clearAuth: () => void;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -18,6 +19,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const saved = localStorage.getItem("auth_stage");
     if (saved === "authenticated" || saved === "onboarding" || saved === "logged_out") {
       setStage(saved);
+    } else {
+      // If no valid saved state, ensure we start from logged_out
+      localStorage.setItem("auth_stage", "logged_out");
     }
   }, []);
 
@@ -29,7 +33,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     stage,
     login: () => setStage("onboarding"),
     completeOnboarding: () => setStage("authenticated"),
-    logout: () => setStage("logged_out"),
+    logout: () => {
+      setStage("logged_out");
+      localStorage.setItem("auth_stage", "logged_out");
+    },
+    clearAuth: () => {
+      localStorage.removeItem("auth_stage");
+      setStage("logged_out");
+    },
   }), [stage]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
-import { Columns2, Plus, MessageSquareText, FolderCheck, Settings, User, ChevronDown, Copy, ArrowUp, ArrowRight } from 'lucide-react';
+import { Columns2, Plus, MessageSquareText, FolderCheck, Settings, User, ChevronDown, Copy, ArrowUp, ArrowRight, LogOut } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { useAuth } from '@/lib/auth';
 const Index = () => {
   const [inputValue, setInputValue] = useState('');
+  const { logout, clearAuth } = useAuth();
   const sidebarIcons = [{
     icon: Columns2,
     label: 'Expandir menu'
@@ -42,10 +44,17 @@ const Index = () => {
             </button>)}
         </div>
         
-        {/* Ícone User na parte inferior */}
-        <div className="pb-8">
+        {/* Ícone User e Logout na parte inferior */}
+        <div className="pb-8 flex flex-col space-y-4">
           <button className="text-white hover:opacity-75 transition-opacity duration-200 group relative" title={sidebarIcons[sidebarIcons.length - 1].label}>
             <User size={24} strokeWidth={1.5} />
+          </button>
+          <button 
+            onClick={logout}
+            className="text-white hover:opacity-75 transition-opacity duration-200 group relative" 
+            title="Logout"
+          >
+            <LogOut size={24} strokeWidth={1.5} />
           </button>
         </div>
       </div>
@@ -54,9 +63,20 @@ const Index = () => {
       <div className="flex-1 flex flex-col max-w-[940px] ml-20">
         {/* Header */}
         <div className="pt-[66px] pl-[8px] pb-[48px]">
-          <div className="flex items-center text-[hsl(var(--smartshelf-text))] font-fustat font-light text-[32px]">
-            <span>Assunto: Experiência Profissional</span>
-            <ChevronDown size={20} className="ml-2" />
+          <div className="flex items-center justify-between text-[hsl(var(--smartshelf-text))] font-fustat font-light text-[32px]">
+            <div className="flex items-center">
+              <span>Assunto: Experiência Profissional</span>
+              <ChevronDown size={20} className="ml-2" />
+            </div>
+            {/* Development button - remove in production */}
+            <Button 
+              onClick={clearAuth}
+              variant="outline" 
+              size="sm"
+              className="text-xs"
+            >
+              Clear Auth (Dev)
+            </Button>
           </div>
         </div>
 


### PR DESCRIPTION
Ensure the complete authentication flow is shown by correctly initializing and managing the authentication state in `localStorage`.

The app was previously skipping the sign-in page due to a pre-existing authentication state in `localStorage`. This PR ensures the state defaults to 'logged_out' if no valid state is found, and adds explicit logout and a temporary 'Clear Auth (Dev)' button for easier testing of the full flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-c31354c9-0ad5-46aa-87e0-ff3ca80f9b3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c31354c9-0ad5-46aa-87e0-ff3ca80f9b3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

